### PR TITLE
fix: suppress esbuild CSS minify warning

### DIFF
--- a/web/nuxt.config.ts
+++ b/web/nuxt.config.ts
@@ -7,6 +7,15 @@ export default defineNuxtConfig({
     preset: 'vercel',
   },
 
+  vite: {
+    css: {
+      devSourcemap: true,
+    },
+    build: {
+      cssMinify: false,
+    },
+  },
+
   runtimeConfig: {
     public: {
       wsUrl: process.env.NUXT_PUBLIC_WS_URL || 'ws://localhost:3001',


### PR DESCRIPTION
Disables esbuild CSS minification - Tailwind/PostCSS already handles it. Eliminates the esbuild CSS minify warning on build.