### PR TITLE
fix: remove redundant named middleware reference

### DIFF
--- a/web/pages/index.vue
+++ b/web/pages/index.vue
@@ -18,7 +18,5 @@
 </template>
 
 <script setup lang="ts">
-definePageMeta({
-  middleware: 'auth',
-})
+
 </script>


### PR DESCRIPTION
## Problem
`pages/index.vue` referenced `middleware: 'auth'` in `definePageMeta`, but the middleware file is `auth.global.ts` (global -- applies to all routes automatically). Nuxt does not register `.global` files as named middleware, causing the "Unknown route middleware: 'auth'" error on load.

## Fix
Removed the redundant `definePageMeta({ middleware: 'auth' })` block from `pages/index.vue`. The global middleware handles auth for all routes without explicit referencing.

## Verification
- Build: clean
- Tests: 106/106 green
- `.nuxt/types/middleware.d.ts` now correctly shows `MiddlewareKey = never` (no named middleware needed)
